### PR TITLE
Fix: changed signing function call in publish plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -152,6 +152,6 @@ signing {
 
     if (signingKeyId != null) {
         useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
-        sign(publishing.publications)
+        sign(configurations.archives.get())
     }
 }

--- a/src/main/kotlin/dev/icerock/moko/gradle/PublicationPlugin.kt
+++ b/src/main/kotlin/dev/icerock/moko/gradle/PublicationPlugin.kt
@@ -77,7 +77,7 @@ class PublicationPlugin : Plugin<Project> {
 
             if (signingKeyId != null) {
                 useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
-                sign(target.extensions.getByType<PublishingExtension>().publications)
+                sign(configuration.artifacts.toString())
             }
         }
     }


### PR DESCRIPTION
Bugfix for #1 

Build run on Master branch that reproduces the issue 

[➜  moko-gradle-plugin-build-log-master.log](https://github.com/icerockdev/moko-gradle-plugin/files/14971603/moko-gradle-plugin-build-log-master.log)

Build run on bugfix/signing-fix branch where build fails as expected due to secrets being different but this build run is not having master branch issue. But if you run with moko secrets it will succeed.

[➜  moko-gradle-plugin-build-log-bugfix:signing-fix.log](https://github.com/icerockdev/moko-gradle-plugin/files/14971607/moko-gradle-plugin-build-log-bugfix.signing-fix.log)



